### PR TITLE
Login page v2

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -6,12 +6,17 @@
     存放容器模型
 * pages
     放置page的設計
-    * login_page
-        登入頁面，初始頁面，不能用"返回"回到此頁面，只能通過logout回到此頁面，setting沒有logout可以使用
-    * home_page
-        使用top bar或bottom bar切換Dashboard, ProcurementPage, InventoryPage, OrderPage, CalanderPage
+  * routes
+    放置各個頁面的route以供切換
+  * login_page
+    登入頁面，初始頁面，不能用"返回"回到此頁面，只能通過logout回到此頁面，setting沒有logout可以使用
+  * home_page
+    使用top bar或bottom bar切換Dashboard, ProcurementPage, InventoryPage, OrderPage, CalanderPage
 * providers
     存放provider的地方
+  * auth_provider
+    處理login邏輯，將account與password傳至後方確認
+    如果帳號密碼正確，會建立Employee並將用戶個人資料存入此provider，方便後續操作
 * services
     放service，後端連結之類的
 * theme
@@ -20,3 +25,44 @@
     存放一些共用的widgets
 * main.dart
     程式的起點，連結頁面的route表，並定義最初的route位置
+
+## 傳輸相關協定
+### condition
+傳輸基本。
+需包含String type, Map<String, dynamic> data
+使用serialization將資料轉為String，用來傳輸給後端
+
+### auth_data
+condition.data裝載用
+需包含String account, String password
+使用serialization_json將資料轉為Map<String, dynamic>，以便進行condition.serialization()
+
+### login 格式
+#### client -> server
+```json
+{
+  "type" : "Login", 
+  "data" : {
+    "account" : "account", 
+    "password" : "password"
+  }
+}
+```
+#### server -> client (success)
+employee_email 與 employee_phone可以為空，整行不填
+```json
+{
+  "success" : true, 
+  "name" : "employee_name", 
+  "id" : "employee_id", 
+  "email" : "employee_email?",
+  "phone" : "employee_phone?"
+}
+```
+### server -> client (fail)
+```json
+{
+  "success" : false,
+  "message" : "error_message"
+}
+```

--- a/lib/interface/serializable.dart
+++ b/lib/interface/serializable.dart
@@ -1,3 +1,4 @@
 abstract class Serializable {
-  void serialization();
+  String serialization();
+  Map<String, dynamic> serialization_json();
 }

--- a/lib/models/auth_data.dart
+++ b/lib/models/auth_data.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+
+import 'package:invenza/interface/serializable.dart';
+
+class AuthData implements Serializable{
+  String account;
+  String password;
+  AuthData(this.account, this.password);
+
+  @override
+  String serialization() {
+    // TODO: implement serialization
+    throw UnimplementedError();
+  }
+
+  @override
+  Map<String, dynamic> serialization_json() {
+    return {
+      'account' : account,
+      'password' : password,
+    };
+  }
+}

--- a/lib/models/condition.dart
+++ b/lib/models/condition.dart
@@ -1,9 +1,25 @@
-class Condition {
-  String type;
-  String? sortByValue;
-  bool? isIncreasing;
-  bool? isFinished;
-  int? num;
+import 'dart:convert';
 
-  Condition(this.type);
+import 'package:invenza/interface/serializable.dart';
+
+class Condition implements Serializable{
+  final String type;
+  final Map<String, dynamic> data;
+
+  Condition(this.type, this.data);
+
+  @override
+  String serialization() {
+    Map<String, dynamic> textMap =  {
+      'type' : type,
+      'data' : data,
+    };
+    return jsonEncode(textMap);
+  }
+
+  @override
+  Map<String, dynamic> serialization_json() {
+    // TODO: implement serialization_json
+    throw UnimplementedError();
+  }
 }

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -17,7 +17,7 @@ class LoginPage extends ConsumerStatefulWidget {
 
 class _LoginPageState extends ConsumerState<LoginPage> {
   final _formKey = GlobalKey<FormState>();
-  final _usernameController = TextEditingController();
+  final _accountController = TextEditingController();
   final _passwordController = TextEditingController();
   bool _obscurePassword = true;
   String? _errorMessage;
@@ -45,7 +45,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     print('build login page');
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Color(0xFF4A90E2),
+        backgroundColor: Color(0xFF58BFE3),
         leading: const Icon(Icons.insert_emoticon_sharp),
         actions: [
           PopupMenuButton(
@@ -115,6 +115,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                   padding: const EdgeInsets.only(top: 8.0),
                   child: Text(
                     _errorMessage!,
+                    style: TextStyle(color: Colors.red),
                   ),
                 ),
             ],
@@ -127,7 +128,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   Widget _buildAccountTextFormField() {
     print('build account input');
     return TextFormField(
-      controller: _usernameController,
+      controller: _accountController,
       maxLength: 20,
       decoration: InputDecoration(
         labelText: '帳號',

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -24,7 +24,22 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
+    // 偵測auth_provider狀態，來切換頁面與顯示錯誤訊息
+    ref.listen<AsyncValue<void>>(authProvider, (prev, next) {
+      next.whenOrNull(
+        data: (_) {
+          // 登入成功 -> home page
+          Navigator.pushReplacementNamed(context, '/home');
+        },
+        error: (err, _) {
+          // 顯示錯誤
+          setState(() => _errorMessage = err.toString());
+        },
+      );
+    });
+
     print('build login page');
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Color(0xFF58BFE3),

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -22,24 +22,6 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   bool _obscurePassword = true;
   String? _errorMessage;
 
-  void _login() {
-    print('check data pattern');
-    if (!_formKey.currentState!.validate()) return;
-
-    final username = _usernameController.text.trim();
-    final password = _passwordController.text.trim();
-
-    // 模擬登入邏輯 發送後端確認
-    if (username == "admin" && password == "123456") {
-      Employee employee = Employee(username, "000000001", Association(null, null));
-      Navigator.pushReplacementNamed(context, '/home');
-      log('succeed logging in');
-      ref.read(authProvider.notifier).state = employee;
-    } else {
-      setState(() => _errorMessage = "帳號或密碼錯誤");
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     print('build login page');
@@ -109,7 +91,14 @@ class _LoginPageState extends ConsumerState<LoginPage> {
               _buildPasswordTextFormField(),
               Row(children: [Text('忘記密碼'),],),
               SizedBox(height: 80),
-              ElevatedButton(onPressed: _login, child: Text('登入')),
+              ElevatedButton(
+                onPressed: () async {
+                  String account = _accountController.text.trim();
+                  String password = _passwordController.text.trim();
+                  await ref.read(authProvider.notifier).login(account, password, _formKey);
+                },
+                child: Text('登入')
+              ),
               if (_errorMessage != null)
                 Padding(
                   padding: const EdgeInsets.only(top: 8.0),

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,4 +1,50 @@
+import 'dart:convert';
+
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:invenza/models/association.dart';
+import 'package:invenza/models/auth_data.dart';
+import 'package:invenza/models/condition.dart';
 import 'package:invenza/models/employee.dart';
 
-final authProvider = StateProvider<Employee?>((ref) => null);
+final authProvider = StateNotifierProvider<AuthController, AsyncValue<Employee?>>(
+    (ref) => AuthController(),
+);
+
+class AuthController extends StateNotifier<AsyncValue<Employee?>> {
+  AuthController() : super(const AsyncValue.data(null));
+
+  Future<void> login(String account, String password, GlobalKey<FormState> formKey) async {
+    if (!formKey.currentState!.validate()) return; // 確認account, password格式是否正確
+
+    state = const AsyncValue.loading(); // 設定狀態為loading
+    
+    try {
+      final response = await http.post(
+        Uri.parse('http://localhost:8080/login'),
+        headers: {'Content-Type': 'application/json'},
+        body: Condition(
+            'Login', AuthData(account, password).serialization_json()
+            ).serialization(),
+      );
+
+      final data = jsonDecode(response.body);
+      if (response.statusCode == 200 && data['success'] == true) {
+        Employee employee = Employee(data['name'], data['id'], Association(data['email'], data['phone']));
+        print(employee.getName());
+        print(employee.getID());
+        print(employee.getAssociation());
+        state = AsyncValue.data(employee); // 表示成功
+      } else {
+        throw Exception(data['message'] ?? '登入失敗');
+      }
+    } catch (e, st) {
+      state = AsyncValue.error(e, st); // 錯誤會回傳到 UI
+    }
+  }
+
+  void reset() {
+    state = const AsyncValue.data(null);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,6 +83,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.6"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -216,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.5.1
+  http: ^0.13.6
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
使用RESTful API處理輸入問題，後端使用python寫的簡易localhost:8080本地端，僅識別account: admin, password: 123456
將login邏輯分離到auth_provider處理

更改傳輸後端架構condition組成
{
'type' : 執行指令
'data' : 附帶資料
}
更改serializable的函式，新增serialization_json以應對condition與其data鑲嵌class的處理